### PR TITLE
Rewrite README to conform to README standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,113 @@
-# AWS SigV4 Proxy
-![GitHub release (with filter)](https://img.shields.io/github/v/release/ivoronin/amzproxy)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ivoronin/amzproxy)](https://goreportcard.com/report/github.com/ivoronin/amzproxy)
-![GitHub last commit (branch)](https://img.shields.io/github/last-commit/ivoronin/amzproxy/main)
-![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/ivoronin/amzproxy/goreleaser.yml)
-![GitHub top language](https://img.shields.io/github/languages/top/ivoronin/amzproxy)
+# amzproxy
 
-A lightweight HTTP proxy that transparently signs requests using AWS Signature Version 4. This tool allows you to forward HTTP requests to AWS services while automatically applying proper authentication headers using your default AWS credentials.
+HTTP reverse proxy that signs requests with AWS Signature Version 4
 
-## 🚀 Features
+[![CI](https://github.com/ivoronin/amzproxy/actions/workflows/test.yml/badge.svg)](https://github.com/ivoronin/amzproxy/actions/workflows/test.yml)
+[![Release](https://img.shields.io/github/v/release/ivoronin/amzproxy)](https://github.com/ivoronin/amzproxy/releases)
 
-- Acts as a reverse proxy for AWS services
-- Automatically signs all forwarded requests with SigV4
-- Supports any AWS service with minimal configuration
-- Uses default AWS credential provider chain (env, config files, EC2/ECS roles)
-- Logs incoming requests for observability
-
-## 🔧 Usage
-
-### Command Line Arguments
+[Overview](#overview) · [Features](#features) · [Installation](#installation) · [Usage](#usage) · [Configuration](#configuration) · [Requirements](#requirements) · [License](#license)
 
 ```bash
--service string   # AWS service name (e.g., execute-api, es, s3)
--region string    # AWS region (e.g., us-east-1)
--host string      # AWS service host (e.g., search-my-domain.us-east-1.es.amazonaws.com)
-```
-
-### Example
-
-```bash
+# Access OpenSearch Dashboards through IAM authentication
 amzproxy -service es -region us-east-1 -host search-my-domain.us-east-1.es.amazonaws.com
+
+# Then open in browser or use curl
+curl http://localhost:8080/_dashboards/
 ```
 
-Then send requests to:
+## Overview
 
+amzproxy acts as a reverse proxy that intercepts HTTP requests, signs them using AWS Signature Version 4, and forwards them to AWS services. It uses the AWS SDK credential provider chain to obtain credentials (environment variables, shared config files, EC2/ECS instance roles). All requests and responses are logged with timing information.
+
+## Features
+
+- Reverse proxy for any AWS service requiring SigV4 authentication
+- Uses AWS SDK default credential provider chain
+- Logs all requests with method, path, query string, source address, status code, and duration
+- Listens on port 8080
+- Forwards to HTTPS endpoints
+
+## Installation
+
+### GitHub Releases
+
+Download from [Releases](https://github.com/ivoronin/amzproxy/releases).
+
+### Homebrew
+
+```bash
+brew install ivoronin/tap/amzproxy
 ```
-http://localhost:8080/_dashboards/
+
+### Build from source
+
+```bash
+git clone https://github.com/ivoronin/amzproxy.git
+cd amzproxy
+make build
 ```
 
-The proxy will:
+## Usage
 
-1.	Sign the request using AWS SigV4.
-2.	Forward it to https://search-my-domain.us-east-1.es.amazonaws.com/_dashboards/.
-3.	Return the response to the client.
+### Command Line Flags
+
+```bash
+amzproxy -service <service> -region <region> -host <host>
+```
+
+| Flag | Description | Required |
+|------|-------------|----------|
+| `-service` | AWS service name (es, execute-api, s3, etc.) | Yes |
+| `-region` | AWS region (us-east-1, eu-west-1, etc.) | Yes |
+| `-host` | Target AWS service hostname | Yes |
+| `-version` | Print version and exit | No |
+
+### Examples
+
+```bash
+# Proxy to OpenSearch
+amzproxy -service es -region us-east-1 -host search-my-domain.us-east-1.es.amazonaws.com
+
+# Proxy to API Gateway
+amzproxy -service execute-api -region eu-west-1 -host abc123.execute-api.eu-west-1.amazonaws.com
+
+# Proxy to S3
+amzproxy -service s3 -region us-west-2 -host my-bucket.s3.us-west-2.amazonaws.com
+```
+
+### How It Works
+
+1. Start amzproxy with the target service, region, and host
+2. Send HTTP requests to `http://localhost:8080/your/path`
+3. amzproxy signs each request with SigV4 using your AWS credentials
+4. Request is forwarded to `https://<host>/your/path`
+5. Response is returned to the client
+
+## Configuration
+
+amzproxy uses the AWS SDK default credential provider chain. Credentials are resolved in this order:
+
+1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
+2. Shared credentials file (`~/.aws/credentials`)
+3. Shared config file (`~/.aws/config`)
+4. EC2 Instance Metadata Service (IMDS)
+5. ECS container credentials
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_ACCESS_KEY_ID` | AWS access key |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key |
+| `AWS_SESSION_TOKEN` | Session token (for temporary credentials) |
+| `AWS_PROFILE` | Named profile to use from credentials file |
+| `AWS_REGION` | Default region (not used by amzproxy, use `-region` flag) |
+
+## Requirements
+
+- AWS credentials with permissions to access the target service
+- Network access to the target AWS service endpoint
+
+## License
+
+[GPL-3.0](LICENSE)


### PR DESCRIPTION
## Summary

- Restructures README to follow the standard section order: Title + One-liner, Badges, ToC (horizontal), Hero Example, Overview, Features, Installation, Usage, Configuration, Requirements, License
- Reduces badges from 5 to 2 (CI + Release only)
- Removes emojis from section headers
- Removes `$` prompts from code blocks
- Adds complete documentation of all CLI flags in a table format
- Documents AWS credential chain configuration
- Adds multiple usage examples for different AWS services

## Test plan

- [ ] Verify all ToC links work correctly
- [ ] Verify badge links are functional
- [ ] Confirm code blocks are copy-paste ready (no `$` prompts)
- [ ] Review section order matches standard

Generated with Claude Code